### PR TITLE
Place a Post button in catalog.html

### DIFF
--- a/views/board/catalog.html
+++ b/views/board/catalog.html
@@ -34,7 +34,7 @@
 		<tr>
 		{{if not .privs}}
 			<td>Captcha:</td>
-			<td>{{ captcha }}</td>
+			<td>{{ captcha }} <input type="submit" value="Post"></td>
 		{{else}}
 			<td></td>
 			<td><input type="submit" value="Post"></td>


### PR DESCRIPTION
Before the revision, `index.html` had a Post button, but `catalog.html` did not.
After the revision, `index.html` and `catalog.html` both have Post button.
<details><summary> Before </summary> <br>

<img width="960" alt="catalog html before" src="https://user-images.githubusercontent.com/35728132/182524204-6d57c733-d11c-4f47-a969-ce180b2ba249.png">
</details>

<details><summary> After</summary> <br>

![image](https://user-images.githubusercontent.com/35728132/182524390-df395d8f-9760-4f57-8db1-4ef10fc3026c.png)
</details>
